### PR TITLE
Add additional IAM roles for Stackdriver

### DIFF
--- a/dm-setup/iam.jinja
+++ b/dm-setup/iam.jinja
@@ -57,6 +57,3 @@ resources:
       - role: roles/errorreporting.writer
         members:
         - serviceAccount:$(ref.{{ env['deployment'] }}-cluster-sa.email)
-      - role: roles/clouddebugger.agent
-        members:
-        - serviceAccount:$(ref.{{ env['deployment'] }}-cluster-sa.email)


### PR DESCRIPTION
Stackdriver Trace now works, there is still an additional issue with Error Reporting which looks like it could be related to newer versions of fluentd (see chatroom for reference), though interestingly I couldn't get the error to fire in a manually deployed 1.9.6-gke.1 cluster either. Worth investigating is how/if the error reporting API is called directly by the service.