### PR TITLE
Revert VM OS from Ubuntu back to COS

### DIFF
--- a/dm-setup/cluster.jinja
+++ b/dm-setup/cluster.jinja
@@ -66,7 +66,6 @@ resources:
           cidrBlock: {{ properties['masterAuthorizedNetwork'] }}
       nodeConfig:
         machineType: n1-standard-4
-        imageType: ubuntu
         oauthScopes:
         - https://www.googleapis.com/auth/cloud-platform
         serviceAccount: $(ref.sa-{{ env['project_number'] }}-cluster.email)

--- a/dm-setup/qwiklabs.jinja
+++ b/dm-setup/qwiklabs.jinja
@@ -41,7 +41,7 @@ resources:
     location: us-central1-f
     purpose: workloads
     apiVersion: v1beta1
-    kubernetesVersion: "1.10"
+    kubernetesVersion: "1.10.4"
     monitoringService: monitoring.googleapis.com/kubernetes
     loggingService: logging.googleapis.com/kubernetes
     sockShop: "installed"
@@ -51,7 +51,7 @@ resources:
     location: us-east4-b
     purpose: workloads
     apiVersion: v1beta1
-    kubernetesVersion: "1.10"
+    kubernetesVersion: "1.10.4"
     monitoringService: monitoring.googleapis.com/kubernetes
     loggingService: logging.googleapis.com/kubernetes
 - name: spinnaker
@@ -59,6 +59,7 @@ resources:
   properties:
     zone: us-central1-f
     purpose: spinnaker
+    kubernetesVersion: "1.10.4"
 - name: student-vm
   type: student-vm.jinja
   metadata:


### PR DESCRIPTION
As a temporary workaround for a COS kernel configuration issue that affected Istio, we moved from COS to Ubuntu a few weeks ago, so as not to be blocked awaiting the fix. In GKE 1.10.4 this issue is fixed, so this PR reverts back to COS.