### PR TITLE
bug causes improper vm startup after istio-1.0.0 was released

### DIFF
--- a/dm-setup/student-vm-startup.sh
+++ b/dm-setup/student-vm-startup.sh
@@ -106,7 +106,7 @@ for CLUSTER_INFO in ${WORKLOAD_CLUSTERS}; do
     until timeout 10 helm version; do sleep 10; done
 
     # Install Istio
-    ISTIO_VERSION=0.8.0
+    export ISTIO_VERSION=0.8.0
     curl -L https://git.io/getLatestIstio | sh -
     pushd istio-${ISTIO_VERSION}/
     helm install -n istio --namespace=istio-system --set sidecar-injector.enabled=true install/kubernetes/helm/istio


### PR DESCRIPTION
I've noticed that ISTIO_VERSIO variable wasn't exported that caused istio-1.0.0 be downloaded, instead of istio-0.8.0.